### PR TITLE
Enable commands only when a file pane is active

### DIFF
--- a/lib/to-the-hubs.coffee
+++ b/lib/to-the-hubs.coffee
@@ -4,10 +4,11 @@ module.exports =
   activate: ->
     return unless project.getRepo()?
 
-    rootView.command 'github:open', ->
-      if itemPath = rootView.getActivePaneItem()?.getPath?()
-        GitHubFile.fromPath(itemPath).open()
+    rootView.eachPane (pane) ->
+      pane.command 'github:open', ->
+        if itemPath = rootView.getActivePaneItem()?.getPath?()
+          GitHubFile.fromPath(itemPath).open()
 
-    rootView.command 'github:blame', ->
-      if itemPath = rootView.getActivePaneItem()?.getPath?()
-        GitHubFile.fromPath(itemPath).blame()
+      pane.command 'github:blame', ->
+        if itemPath = rootView.getActivePaneItem()?.getPath?()
+          GitHubFile.fromPath(itemPath).blame()


### PR DESCRIPTION
If there are no file panes open in Atom, it doesn't make sense to show the `GitHub: Open` and `GitHub: Blame` commands in the command palette. Those commands can't do anything in that scenario.

So, instead of _always_ making these commands available, let's make them available only when a file pane is active.
