### PR TITLE
Use alt instead of ctrl

### DIFF
--- a/keymaps/to-the-hubs.cson
+++ b/keymaps/to-the-hubs.cson
@@ -1,5 +1,5 @@
 '.workspace':
-  'ctrl-g o': 'github:open'
-  'ctrl-g b': 'github:blame'
-  'ctrl-g h': 'github:history'
-  'ctrl-g c': 'github:copy-url'
+  'alt-g o': 'github:open'
+  'alt-g b': 'github:blame'
+  'alt-g h': 'github:history'
+  'alt-g c': 'github:copy-url'


### PR DESCRIPTION
I want to add `cmd-l` to select the current line which means `go-to-line` (currently `cmd-l`) would move to `ctrl-g` (same as Sublime).

To do this `ctrl-g` needs to be freed up by this package.

`alt-g` is currently the © symbol which seems okay to give up.

/cc @jasonrudolph please let me know if you object to this and we can figure something else out.
