### PR TITLE
Add config setting to include line numbers in URLs

### DIFF
--- a/lib/github-file.coffee
+++ b/lib/github-file.coffee
@@ -20,32 +20,36 @@ class GitHubFile
       @reportValidationErrors()
 
   # Public
-  blame: ->
+  blame: (lineRange) ->
     if @isOpenable()
-      @openUrlInBrowser(@blameUrl())
+      @openUrlInBrowser(@blameUrl() + @getLineRangeSuffix(lineRange))
     else
       @reportValidationErrors()
 
-  history: ->
+  history: (lineRange) ->
     if @isOpenable()
-      @openUrlInBrowser(@historyUrl())
+      @openUrlInBrowser(@historyUrl() + @getLineRangeSuffix(lineRange))
     else
       @reportValidationErrors()
 
   copyUrl: (lineRange) ->
     if @isOpenable()
       url = @blobUrl()
-      if lineRange
-        lineRange = Range.fromObject(lineRange)
-        startRow = lineRange.start.row + 1
-        endRow = lineRange.end.row + 1
-        if startRow is endRow
-          url += "#L#{startRow}"
-        else
-          url += "#L#{startRow}-L#{endRow}"
-      atom.clipboard.write(url)
+      atom.clipboard.write(url + @getLineRangeSuffix(lineRange))
     else
       @reportValidationErrors()
+
+  getLineRangeSuffix: (lineRange) ->
+    if lineRange and atom.config.get('open-on-github.includeLineNumbersInUrls')
+      lineRange = Range.fromObject(lineRange)
+      startRow = lineRange.start.row + 1
+      endRow = lineRange.end.row + 1
+      if startRow is endRow
+        "#L#{startRow}"
+      else
+        "#L#{startRow}-L#{endRow}"
+    else
+      ''
 
   # Public
   isOpenable: ->

--- a/lib/open-on-github.coffee
+++ b/lib/open-on-github.coffee
@@ -1,17 +1,20 @@
 GitHubFile  = require './github-file'
 
 module.exports =
+  configDefaults:
+    includeLineNumbersInUrls: true
+
   activate: ->
     return unless atom.project.getRepo()?
 
     atom.workspaceView.eachPane (pane) ->
       pane.command 'open-on-github:file', ->
         if itemPath = getActivePath()
-          GitHubFile.fromPath(itemPath).open()
+          GitHubFile.fromPath(itemPath).open(getSelectedRange())
 
       pane.command 'open-on-github:blame', ->
         if itemPath = getActivePath()
-          GitHubFile.fromPath(itemPath).blame()
+          GitHubFile.fromPath(itemPath).blame(getSelectedRange())
 
       pane.command 'open-on-github:history', ->
         if itemPath = getActivePath()

--- a/spec/github-file-spec.coffee
+++ b/spec/github-file-spec.coffee
@@ -154,6 +154,7 @@ describe "GitHubFile", ->
 
       beforeEach ->
         setupWorkingDir(fixtureName)
+        atom.config.set('open-on-github.includeLineNumbersInUrls', true)
         githubFile = setupGithubFile()
 
       afterEach ->


### PR DESCRIPTION
`open-on-github.includeLineNumbersInUrls` now controls whether the line numbers are included in the opened URLs.

This setting in enabled by default.

Closes atom/atom#1478
