### PR TITLE
Add open branch compare page

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ When editing a file in Atom, use the command palette or keyboard shortcuts to:
 - Open the file on github.com `alt-g, o`
 - Open the blame view for the file on github.com `alt-g, b`
 - Open the history view for the file on github.com `alt-g, h`
+- Open the compare page for the current branch on github.com `alt-g, r`
 - Copy the github.com URL for the currently selected lines `alt-g, c`
 
 ![Command Palette](https://f.cloud.github.com/assets/671378/2241755/23cb72f8-9ce2-11e3-9109-36c76a030f6a.png)

--- a/keymaps/to-the-hubs.cson
+++ b/keymaps/to-the-hubs.cson
@@ -3,3 +3,4 @@
   'alt-g b': 'open-on-github:blame'
   'alt-g h': 'open-on-github:history'
   'alt-g c': 'open-on-github:copy-url'
+  'alt-g r': 'open-on-github:branch-compare'

--- a/lib/github-file.coffee
+++ b/lib/github-file.coffee
@@ -39,6 +39,12 @@ class GitHubFile
     else
       @reportValidationErrors()
 
+  openBranchCompare: ->
+    if @isOpenable()
+      @openUrlInBrowser(@branchCompareUrl())
+    else
+      @reportValidationErrors()
+
   getLineRangeSuffix: (lineRange) ->
     if lineRange and atom.config.get('open-on-github.includeLineNumbersInUrls')
       lineRange = Range.fromObject(lineRange)
@@ -76,15 +82,19 @@ class GitHubFile
 
   # Internal
   blobUrl: ->
-    "#{@githubRepoUrl()}/blob/#{@branch()}/#{@repoRelativePath()}"
+    "#{@githubRepoUrl()}/blob/#{@branchName()}/#{@repoRelativePath()}"
 
   # Internal
   blameUrl: ->
-    "#{@githubRepoUrl()}/blame/#{@branch()}/#{@repoRelativePath()}"
+    "#{@githubRepoUrl()}/blame/#{@branchName()}/#{@repoRelativePath()}"
 
   # Internal
   historyUrl: ->
-    "#{@githubRepoUrl()}/commits/#{@branch()}/#{@repoRelativePath()}"
+    "#{@githubRepoUrl()}/commits/#{@branchName()}/#{@repoRelativePath()}"
+
+  # Internal
+  branchCompareUrl: ->
+    "#{@githubRepoUrl()}/compare/#{@branchName()}"
 
   # Internal
   gitUrl: ->
@@ -117,7 +127,7 @@ class GitHubFile
     branchRemote
 
   # Internal
-  branch: ->
+  branchName: ->
     shortBranch = @repo.getShortHead()
     return null unless shortBranch
 

--- a/lib/open-on-github.coffee
+++ b/lib/open-on-github.coffee
@@ -24,6 +24,10 @@ module.exports =
         if itemPath = getActivePath()
           GitHubFile.fromPath(itemPath).copyUrl(getSelectedRange())
 
+      pane.command 'open-on-github:branch-compare', ->
+        if itemPath = atom.project.getPath()
+          GitHubFile.fromPath(itemPath).openBranchCompare()
+
 getActivePath = ->
   atom.workspaceView.getActivePaneItem()?.getPath?()
 

--- a/menus/open-on-github.cson
+++ b/menus/open-on-github.cson
@@ -5,6 +5,7 @@
       'label': 'Open On GitHub'
       'submenu': [
         { 'label': 'Blame', 'command': 'open-on-github:blame' }
+        { 'label': 'Branch Compare', 'command': 'open-on-github:branch-compare' }
         { 'label': 'Copy URL', 'command': 'open-on-github:copy-url' }
         { 'label': 'File', 'command': 'open-on-github:file' }
         { 'label': 'History', 'command': 'open-on-github:history' }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "open-on-github:file",
     "open-on-github:blame",
     "open-on-github:history",
-    "open-on-github:copy-url"
+    "open-on-github:copy-url",
+    "open-on-github:branch-compare"
   ],
   "engines": {
     "atom": "*"

--- a/spec/github-file-spec.coffee
+++ b/spec/github-file-spec.coffee
@@ -164,6 +164,23 @@ describe "GitHubFile", ->
           expect(githubFile.openUrlInBrowser).toHaveBeenCalledWith \
             'https://github.com/some-user/some-repo/blame/master/some-dir/some-file.md'
 
+    describe "branchCompare", ->
+      describe "when the file is openable on GitHub.com", ->
+        fixtureName = 'github-remote'
+
+        beforeEach ->
+          setupWorkingDir(fixtureName)
+          githubFile = setupGithubFile()
+
+        afterEach ->
+          teardownWorkingDirAndRestoreFixture(fixtureName)
+
+        it "opens the GitHub.com branch compare URL for the file", ->
+          spyOn(githubFile, 'openUrlInBrowser')
+          githubFile.openBranchCompare()
+          expect(githubFile.openUrlInBrowser).toHaveBeenCalledWith \
+            'https://github.com/some-user/some-repo/compare/master'
+
     describe "history", ->
       describe "when the file is openable on GitHub.com", ->
         fixtureName = 'github-remote'


### PR DESCRIPTION
Add an option to open the branch compare page on Github. This is useful for browsing the branch generally outside the scope of a single file and creating new pull requests.
