### PR TITLE
Support ssh:// style remotes

### DIFF
--- a/lib/github-file.coffee
+++ b/lib/github-file.coffee
@@ -117,12 +117,10 @@ class GitHubFile
     url = @gitUrl()
     if url.match /https:\/\/[^\/]+\// # e.g., https://github.com/foo/bar.git
       url = url.replace(/\.git$/, '')
-    else if url.match /git@[^:]+:/    # e.g., git@github.com:foo/bar.git
-      url = url.replace /^git@([^:]+):(.+)$/, (match, host, repoPath) ->
+    else if url.match /git@[^:]+:?/    # e.g., git@github.com:foo/bar.git
+      url = url.replace /^(?:ssh:\/\/)?git@([^:/]+)[:\/](.+)$/, (match, host, repoPath) ->
         repoPath = repoPath.replace(/^\/+/, '') # replace leading slashes
         "http://#{host}/#{repoPath}".replace(/\.git$/, '')
-    else if url.match /ssh:\/\/git@([^\/]+)\//    # e.g., ssh://git@github.com/foo/bar.git
-      url = "http://#{url.substring(10).replace(/\.git$/, '')}"
     else if url.match /^git:\/\/[^\/]+\// # e.g., git://github.com/foo/bar.git
       url = "http#{url.substring(3).replace(/\.git$/, '')}"
 

--- a/lib/github-file.coffee
+++ b/lib/github-file.coffee
@@ -121,6 +121,8 @@ class GitHubFile
       url = url.replace /^git@([^:]+):(.+)$/, (match, host, repoPath) ->
         repoPath = repoPath.replace(/^\/+/, '') # replace leading slashes
         "http://#{host}/#{repoPath}".replace(/\.git$/, '')
+    else if url.match /ssh:\/\/git@([^\/]+)\//    # e.g., ssh://git@github.com/foo/bar.git
+      url = "http://#{url.substring(10).replace(/\.git$/, '')}"
     else if url.match /^git:\/\/[^\/]+\// # e.g., git://github.com/foo/bar.git
       url = "http#{url.substring(3).replace(/\.git$/, '')}"
 

--- a/spec/github-file-spec.coffee
+++ b/spec/github-file-spec.coffee
@@ -304,6 +304,10 @@ describe "GitHubFile", ->
       githubFile.gitUrl = -> "git://github.com/foo/bar.git"
       expect(githubFile.githubRepoUrl()).toBe "http://github.com/foo/bar"
 
+    it "returns the GitHub.com URL for a ssh:// URL", ->
+      githubFile.gitUrl = -> "ssh://git@github.com/foo/bar.git"
+      expect(githubFile.githubRepoUrl()).toBe "http://github.com/foo/bar"
+
     it "returns undefined for Bitbucket URLs", ->
       githubFile.gitUrl = -> "https://bitbucket.org/somebody/repo.git"
       expect(githubFile.githubRepoUrl()).toBeUndefined()


### PR DESCRIPTION
Support ssh:// style remotes
e.g., ssh://git@github.com/foo/bar.git