### PR TITLE
Add ability to open on master branch

### DIFF
--- a/lib/github-file.coffee
+++ b/lib/github-file.coffee
@@ -23,6 +23,12 @@ class GitHubFile
     else
       @reportValidationErrors()
 
+  openOnMaster: (lineRange) ->
+    if @isOpenable()
+      @openUrlInBrowser(@blobUrlForMaster() + @getLineRangeSuffix(lineRange))
+    else
+      @reportValidationErrors()
+
   # Public
   blame: (lineRange) ->
     if @isOpenable()
@@ -101,6 +107,9 @@ class GitHubFile
   # Internal
   blobUrl: ->
     "#{@githubRepoUrl()}/blob/#{@encodeSegments(@branchName())}/#{@encodeSegments(@repoRelativePath())}"
+
+  blobUrlForMaster: ->
+    "#{@githubRepoUrl()}/blob/master/#{@encodeSegments(@repoRelativePath())}"
 
   # Internal
   shaUrl: ->

--- a/lib/github-file.coffee
+++ b/lib/github-file.coffee
@@ -23,6 +23,7 @@ class GitHubFile
     else
       @reportValidationErrors()
 
+  # Public
   openOnMaster: (lineRange) ->
     if @isOpenable()
       @openUrlInBrowser(@blobUrlForMaster() + @getLineRangeSuffix(lineRange))
@@ -106,8 +107,9 @@ class GitHubFile
 
   # Internal
   blobUrl: ->
-    "#{@githubRepoUrl()}/blob/#{@encodeSegments(@branchName())}/#{@encodeSegments(@repoRelativePath())}"
+    "#{@githubRepoUrl()}/blob/#{@remoteBranchName()}/#{@encodeSegments(@repoRelativePath())}"
 
+  # Internal
   blobUrlForMaster: ->
     "#{@githubRepoUrl()}/blob/master/#{@encodeSegments(@repoRelativePath())}"
 
@@ -117,11 +119,11 @@ class GitHubFile
 
   # Internal
   blameUrl: ->
-    "#{@githubRepoUrl()}/blame/#{@encodeSegments(@branchName())}/#{@encodeSegments(@repoRelativePath())}"
+    "#{@githubRepoUrl()}/blame/#{@remoteBranchName()}/#{@encodeSegments(@repoRelativePath())}"
 
   # Internal
   historyUrl: ->
-    "#{@githubRepoUrl()}/commits/#{@encodeSegments(@branchName())}/#{@encodeSegments(@repoRelativePath())}"
+    "#{@githubRepoUrl()}/commits/#{@remoteBranchName()}/#{@encodeSegments(@repoRelativePath())}"
 
   # Internal
   issuesUrl: ->
@@ -194,3 +196,8 @@ class GitHubFile
     return shortBranch unless branchMerge.indexOf('refs/heads/') is 0
 
     branchMerge.substring(11)
+
+  # Internal
+  remoteBranchName: ->
+    return @encodeSegments(@branchName()) if @remoteName()?
+    "master"

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -13,6 +13,10 @@ module.exports =
         if itemPath = getActivePath()
           GitHubFile.fromPath(itemPath).open(getSelectedRange())
 
+      'open-on-github:file-on-master': ->
+        if itemPath = getActivePath()
+          GitHubFile.fromPath(itemPath).openOnMaster(getSelectedRange())
+
       'open-on-github:blame': ->
         if itemPath = getActivePath()
           GitHubFile.fromPath(itemPath).blame(getSelectedRange())

--- a/menus/open-on-github.cson
+++ b/menus/open-on-github.cson
@@ -8,6 +8,7 @@
         { 'label': 'Branch Compare', 'command': 'open-on-github:branch-compare' }
         { 'label': 'Copy URL', 'command': 'open-on-github:copy-url' }
         { 'label': 'File', 'command': 'open-on-github:file' }
+        { 'label': 'File on Master', 'command': 'open-on-github:file-on-master' }
         { 'label': 'History', 'command': 'open-on-github:history' }
         { 'label': 'Issues', 'command': 'open-on-github:issues' }
         { 'label': 'Repository', 'command': 'open-on-github:repository' }

--- a/spec/fixtures/branch-with-hash-in-name.git/config
+++ b/spec/fixtures/branch-with-hash-in-name.git/config
@@ -8,6 +8,6 @@
 [remote "origin"]
 	url = https://github.com/some-user/some-repo.git
 	fetch = +refs/heads/*:refs/remotes/origin/*
-[branch "foo/bar"]
+[branch "a#b#c"]
 	remote = origin
-	merge = refs/heads/foo/bar
+	merge = "refs/heads/a#b#c"

--- a/spec/github-file-spec.coffee
+++ b/spec/github-file-spec.coffee
@@ -198,6 +198,22 @@ describe "GitHubFile", ->
           expect(githubFile.openUrlInBrowser).toHaveBeenCalledWith \
             'https://git.enterprize.me/some-user/some-repo/blob/master/some-dir/some-file.md'
 
+    describe "openOnMaster", ->
+      fixtureName = 'non-tracked-branch'
+
+      beforeEach ->
+        setupWorkingDir(fixtureName)
+        setupGithubFile()
+
+      afterEach ->
+        teardownWorkingDirAndRestoreFixture(fixtureName)
+
+      it "opens the GitHub.com blob URL for the file", ->
+        spyOn(githubFile, 'openUrlInBrowser')
+        githubFile.openOnMaster()
+        expect(githubFile.openUrlInBrowser).toHaveBeenCalledWith \
+          'https://github.com/some-user/some-repo/blob/master/some-dir/some-file.md'
+
     describe "blame", ->
       describe "when the file is openable on GitHub.com", ->
         fixtureName = 'github-remote'

--- a/spec/github-file-spec.coffee
+++ b/spec/github-file-spec.coffee
@@ -147,12 +147,11 @@ describe "GitHubFile", ->
 
         afterEach ->
           teardownWorkingDirAndRestoreFixture(fixtureName)
-
-        it "opens the GitHub.com blob URL for the file", ->
+        it "opens the GitHub.com blob URL for the file on the master branch", ->
           spyOn(githubFile, 'openUrlInBrowser')
           githubFile.open()
           expect(githubFile.openUrlInBrowser).toHaveBeenCalledWith \
-            'https://github.com/some-user/some-repo/blob/non-tracked-branch/some-dir/some-file.md'
+            'https://github.com/some-user/some-repo/blob/master/some-dir/some-file.md'
 
       describe "when there is no remote", ->
         fixtureName = 'no-remote'
@@ -239,6 +238,22 @@ describe "GitHubFile", ->
             expect(githubFile.openUrlInBrowser).toHaveBeenCalledWith \
               'https://github.com/some-user/some-repo/blame/master/some-dir/some-file.md#L1-L2'
 
+      describe "when the local branch is not tracked", ->
+        fixtureName = 'non-tracked-branch'
+
+        beforeEach ->
+          setupWorkingDir(fixtureName)
+          setupGithubFile()
+
+        afterEach ->
+          teardownWorkingDirAndRestoreFixture(fixtureName)
+
+        it "opens the GitHub.com blame URL for the file on the master branch", ->
+          spyOn(githubFile, 'openUrlInBrowser')
+          githubFile.blame()
+          expect(githubFile.openUrlInBrowser).toHaveBeenCalledWith \
+            'https://github.com/some-user/some-repo/blame/master/some-dir/some-file.md'
+
     describe "branchCompare", ->
       describe "when the file is openable on GitHub.com", ->
         fixtureName = 'github-remote'
@@ -268,6 +283,22 @@ describe "GitHubFile", ->
           teardownWorkingDirAndRestoreFixture(fixtureName)
 
         it "opens the GitHub.com history URL for the file", ->
+          spyOn(githubFile, 'openUrlInBrowser')
+          githubFile.history()
+          expect(githubFile.openUrlInBrowser).toHaveBeenCalledWith \
+            'https://github.com/some-user/some-repo/commits/master/some-dir/some-file.md'
+
+      describe "when the local branch is not tracked", ->
+        fixtureName = 'non-tracked-branch'
+
+        beforeEach ->
+          setupWorkingDir(fixtureName)
+          setupGithubFile()
+
+        afterEach ->
+          teardownWorkingDirAndRestoreFixture(fixtureName)
+
+        it "opens the GitHub.com history URL for the file on the master branch", ->
           spyOn(githubFile, 'openUrlInBrowser')
           githubFile.history()
           expect(githubFile.openUrlInBrowser).toHaveBeenCalledWith \


### PR DESCRIPTION
This adds one new command and modifies three existing commands.

The `open-on-github:file-on-master` command will open the file on the master branch, regardless of what branch you are currently on.

This also modifies the behavior of the `blame` `file` and `history` commands by adding a check to see if the current branch is local or if it has been pushed to GitHub. If it has been pushed, it will preform the action as it currently does. If not, it will default to the master branch to preform the action.

This is inspired by #27 

In order to implement the tests I had to fix what I am assuming is a copy/paste oversight in the test fixtures. The `branch-with-hash-in-name.git/config` and `branch-with-slash-in-name.git/config` files were identical, both only including the branch with a slash. This threw off a the test for the `a#b#c` branch fixture. If this was intentional, or there is some other oversight I am missing, please let me know.

Thanks!