### PR TITLE
Fix for Atom Issue #8794 Remove 'null' text from front-facing messages

### DIFF
--- a/lib/github-file.coffee
+++ b/lib/github-file.coffee
@@ -86,13 +86,22 @@ class GitHubFile
   # Public
   validationErrors: ->
     unless @repo
-      return ["No repository found for path: #{@filePath}."]
+      if @filePath
+        return ["No repository found for  path: #{@filePath}"]
+      else
+        return ["No repository found for path"]
 
     unless @gitUrl()
-      return ["No URL defined for remote: #{@remoteName()}"]
+      if @remoteName()
+        return ["No URL defined for remote filepath: #{@remoteName()}"]
+      else
+        return ["No URL defined for remote filepath"]
 
     unless @githubRepoUrl()
-      return ["Remote URL is not hosted on GitHub: #{@gitUrl()}"]
+      if @gitUrl()
+        return ["Remote URL is not hosted on GitHub: #{@gitUrl()}"]
+      else
+        return ["Remote URL is not hosted on GitHub"]
 
     []
 


### PR DESCRIPTION
Remove 'null' from alert messages if the item that is being printed is 'null'. Fix for atom issue #8794.

This is the original message when the element is 'null':

![messageoriginal](https://cloud.githubusercontent.com/assets/5561632/11446416/72facdda-94eb-11e5-9fa4-076bc2bbc47f.png)

This is the message now:

![message](https://cloud.githubusercontent.com/assets/5561632/11446417/756e15e0-94eb-11e5-8b12-b61e397193b7.png)
