### PR TITLE
Move away from deprecated Electron require syntax

### DIFF
--- a/lib/github-file.coffee
+++ b/lib/github-file.coffee
@@ -1,4 +1,5 @@
-Shell = require 'shell'
+# TODO: Remove the catch once Atom 1.7.0 is released
+try {shell} = require 'electron' catch then shell = require 'shell'
 {Range} = require 'atom'
 parseUrl = require('url').parse
 
@@ -124,7 +125,7 @@ class GitHubFile
 
   # Internal
   openUrlInBrowser: (url) ->
-    Shell.openExternal url
+    shell.openExternal url
 
   # Internal
   blobUrl: ->


### PR DESCRIPTION
Required for atom/atom#10983.