### PR TITLE
add contextual menu commands

### DIFF
--- a/menus/open-on-github.cson
+++ b/menus/open-on-github.cson
@@ -16,3 +16,18 @@
     ]
   }
 ]
+'context-menu': 
+  'atom-text-editor': [{
+    label: 'Open On GitHub',
+    submenu: [
+        { 'label': 'Blame', 'command': 'open-on-github:blame' }
+        { 'label': 'Branch Compare', 'command': 'open-on-github:branch-compare' }
+        { 'label': 'Copy URL', 'command': 'open-on-github:copy-url' }
+        { 'label': 'File', 'command': 'open-on-github:file' }
+        { 'label': 'File on Master', 'command': 'open-on-github:file-on-master' }
+        { 'label': 'History', 'command': 'open-on-github:history' }
+        { 'label': 'Issues', 'command': 'open-on-github:issues' }
+        { 'label': 'Repository', 'command': 'open-on-github:repository' }
+    ]
+}]
+


### PR DESCRIPTION
this allows for the "right-click" contextual menu to show shortcuts for viewing the current file

[Short description of suggestion]

**Steps which explain the enhancement**

1. view any file (that is on github)
2. select the file, a line, or lines like you normally would with "Open On Github"
3. Leave your cursor right where it is & right click with your mouse or trackpad

**Current and suggested behavior**

this adds easier & maybe faster access to Open On Github functionality

**Why would the enhancement be useful to most users**

This adds another way to access existing functionality

**Atom Version:** 1.10.2
**OS and Version:** OS X 10.11.6