### PR TITLE
Use https for github generated links

### DIFF
--- a/lib/github-file.coffee
+++ b/lib/github-file.coffee
@@ -162,11 +162,11 @@ class GitHubFile
     if url.match /git@[^:]+:/    # e.g., git@github.com:foo/bar.git
       url = url.replace /^git@([^:]+):(.+)$/, (match, host, repoPath) ->
         repoPath = repoPath.replace(/^\/+/, '') # replace leading slashes
-        "http://#{host}/#{repoPath}"
+        "https://#{host}/#{repoPath}"
     else if url.match /ssh:\/\/git@([^\/]+)\//    # e.g., ssh://git@github.com/foo/bar.git
-      url = "http://#{url.substring(10)}"
+      url = "https://#{url.substring(10)}"
     else if url.match /^git:\/\/[^\/]+\// # e.g., git://github.com/foo/bar.git
-      url = "http#{url.substring(3)}"
+      url = "https#{url.substring(3)}"
 
     url = url.replace(/\.git$/, '')
     url = url.replace(/\/+$/, '')


### PR DESCRIPTION
Even if github is HSTS preloaded, its good to generate links which are specified as https in case they are used in tools which _dont_ make use of HSTS (e.g. curl, libraries etc...)
