### PR TITLE
Cleanup github-file.js

### DIFF
--- a/lib/github-file.js
+++ b/lib/github-file.js
@@ -12,12 +12,11 @@ export default class GitHubFile {
   }
 
   constructor (filePath) {
-    let rootDirIndex
     this.filePath = filePath
-    let [rootDir] = atom.project.relativizePath(this.filePath)
+    const [rootDir] = atom.project.relativizePath(this.filePath)
 
     if (rootDir != null) {
-      rootDirIndex = atom.project.getPaths().indexOf(rootDir)
+      const rootDirIndex = atom.project.getPaths().indexOf(rootDir)
       this.repo = atom.project.getRepositories()[rootDirIndex]
     }
   }
@@ -25,75 +24,75 @@ export default class GitHubFile {
   // Public
   open (lineRange) {
     if (this.isOpenable()) {
-      return this.openUrlInBrowser(this.blobUrl() + this.getLineRangeSuffix(lineRange))
+      this.openUrlInBrowser(this.blobUrl() + this.getLineRangeSuffix(lineRange))
     } else {
-      return this.reportValidationErrors()
+      this.reportValidationErrors()
     }
   }
 
   // Public
   openOnMaster (lineRange) {
     if (this.isOpenable()) {
-      return this.openUrlInBrowser(this.blobUrlForMaster() + this.getLineRangeSuffix(lineRange))
+      this.openUrlInBrowser(this.blobUrlForMaster() + this.getLineRangeSuffix(lineRange))
     } else {
-      return this.reportValidationErrors()
+      this.reportValidationErrors()
     }
   }
 
   // Public
   blame (lineRange) {
     if (this.isOpenable()) {
-      return this.openUrlInBrowser(this.blameUrl() + this.getLineRangeSuffix(lineRange))
+      this.openUrlInBrowser(this.blameUrl() + this.getLineRangeSuffix(lineRange))
     } else {
-      return this.reportValidationErrors()
+      this.reportValidationErrors()
     }
   }
 
   history () {
     if (this.isOpenable()) {
-      return this.openUrlInBrowser(this.historyUrl())
+      this.openUrlInBrowser(this.historyUrl())
     } else {
-      return this.reportValidationErrors()
+      this.reportValidationErrors()
     }
   }
 
   copyUrl (lineRange) {
     if (this.isOpenable()) {
-      return atom.clipboard.write(this.shaUrl() + this.getLineRangeSuffix(lineRange))
+      atom.clipboard.write(this.shaUrl() + this.getLineRangeSuffix(lineRange))
     } else {
-      return this.reportValidationErrors()
+      this.reportValidationErrors()
     }
   }
 
   openBranchCompare () {
     if (this.isOpenable()) {
-      return this.openUrlInBrowser(this.branchCompareUrl())
+      this.openUrlInBrowser(this.branchCompareUrl())
     } else {
-      return this.reportValidationErrors()
+      this.reportValidationErrors()
     }
   }
 
   openIssues () {
     if (this.isOpenable()) {
-      return this.openUrlInBrowser(this.issuesUrl())
+      this.openUrlInBrowser(this.issuesUrl())
     } else {
-      return this.reportValidationErrors()
+      this.reportValidationErrors()
     }
   }
 
   openPullRequests () {
     if (this.isOpenable()) {
-      return this.openUrlInBrowser(this.pullRequestsUrl())
+      this.openUrlInBrowser(this.pullRequestsUrl())
     } else {
-      return this.reportValidationErrors()
+      this.reportValidationErrors()
     }
   }
 
   openRepository () {
     if (this.isOpenable()) {
-      return this.openUrlInBrowser(this.githubRepoUrl())
+      this.openUrlInBrowser(this.githubRepoUrl())
     } else {
-      return this.reportValidationErrors()
+      this.reportValidationErrors()
     }
   }
 
@@ -140,20 +139,20 @@ export default class GitHubFile {
 
   // Internal
   reportValidationErrors () {
-    let message = this.validationErrors().join('\n')
-    return atom.notifications.addWarning(message)
+    const message = this.validationErrors().join('\n')
+    atom.notifications.addWarning(message)
   }
 
   // Internal
   openUrlInBrowser (url) {
-    return shell.openExternal(url)
+    shell.openExternal(url)
   }
 
   // Internal
   blobUrl () {
-    let gitHubRepoUrl = this.githubRepoUrl()
-    let remoteBranchName = this.remoteBranchName()
-    let repoRelativePath = this.repoRelativePath()
+    const gitHubRepoUrl = this.githubRepoUrl()
+    const remoteBranchName = this.remoteBranchName()
+    const repoRelativePath = this.repoRelativePath()
 
     if (this.isGitHubWikiUrl(gitHubRepoUrl)) {
       return `${gitHubRepoUrl.slice(0, -5)}/wiki/${this.extractFileName(repoRelativePath)}`
@@ -198,13 +197,7 @@ export default class GitHubFile {
   }
 
   encodeSegments (segments = '') {
-    segments = segments.split('/')
-
-    segments = segments.map((segment) => {
-      return encodeURIComponent(segment)
-    })
-
-    return segments.join('/')
+    return segments.split('/').map(segment => encodeURIComponent(segment)).join('/')
   }
 
   // Internal
@@ -214,9 +207,12 @@ export default class GitHubFile {
 
   // Internal
   gitUrl () {
-    let ref
-    let remoteOrBestGuess = (ref = this.remoteName()) != null ? ref : 'origin'
-    return this.repo.getConfigValue(`remote.${remoteOrBestGuess}.url`, this.filePath)
+    const remoteName = this.remoteName()
+    if (remoteName != null) {
+      return this.repo.getConfigValue(`remote.${remoteName}.url`, this.filePath)
+    } else {
+      return this.repo.getConfigValue(`remote.origin.url`, this.filePath)
+    }
   }
 
   // Internal
@@ -234,8 +230,8 @@ export default class GitHubFile {
       url = `http${url.substring(3)}`
     }
 
-    url = url.replace(/\.git$/, '')
-    url = url.replace(/\/+$/, '')
+    // Remove trailing .git and trailing slashes
+    url = url.replace(/\.git$/, '').replace(/\/+$/, '')
 
     if (!this.isBitbucketUrl(url)) {
       return url
@@ -265,25 +261,25 @@ export default class GitHubFile {
 
   // Internal
   remoteName () {
-    let gitConfigRemote = this.repo.getConfigValue('atom.open-on-github.remote', this.filePath)
+    const gitConfigRemote = this.repo.getConfigValue('atom.open-on-github.remote', this.filePath)
 
     if (gitConfigRemote) {
       return gitConfigRemote
     }
 
-    let shortBranch = this.repo.getShortHead(this.filePath)
+    const shortBranch = this.repo.getShortHead(this.filePath)
 
     if (!shortBranch) {
       return null
     }
 
-    let branchRemote = this.repo.getConfigValue(`branch.${shortBranch}.remote`, this.filePath)
+    const branchRemote = this.repo.getConfigValue(`branch.${shortBranch}.remote`, this.filePath)
 
-    if (!(branchRemote && branchRemote.length > 0)) {
-      return null
+    if (branchRemote && branchRemote.length > 0) {
+      return branchRemote
     }
 
-    return branchRemote
+    return null
   }
 
   // Internal
@@ -293,13 +289,13 @@ export default class GitHubFile {
 
   // Internal
   branchName () {
-    let shortBranch = this.repo.getShortHead(this.filePath)
+    const shortBranch = this.repo.getShortHead(this.filePath)
 
     if (!shortBranch) {
       return null
     }
 
-    let branchMerge = this.repo.getConfigValue(`branch.${shortBranch}.merge`, this.filePath)
+    const branchMerge = this.repo.getConfigValue(`branch.${shortBranch}.merge`, this.filePath)
     if (!(branchMerge && branchMerge.length > 11)) {
       return shortBranch
     }
@@ -313,7 +309,7 @@ export default class GitHubFile {
 
   // Internal
   remoteBranchName () {
-    let gitConfigBranch = this.repo.getConfigValue('atom.open-on-github.branch', this.filePath)
+    const gitConfigBranch = this.repo.getConfigValue('atom.open-on-github.branch', this.filePath)
 
     if (gitConfigBranch) {
       return gitConfigBranch

--- a/lib/github-file.js
+++ b/lib/github-file.js
@@ -2,7 +2,7 @@
 
 import {shell} from 'electron'
 import {Range} from 'atom'
-import {parse as parseUrl} from 'url'
+import {parse as parseURL} from 'url'
 import path from 'path'
 
 export default class GitHubFile {
@@ -24,7 +24,7 @@ export default class GitHubFile {
   // Public
   open (lineRange) {
     if (this.isOpenable()) {
-      this.openUrlInBrowser(this.blobUrl() + this.getLineRangeSuffix(lineRange))
+      this.openURLInBrowser(this.blobURL() + this.getLineRangeSuffix(lineRange))
     } else {
       this.reportValidationErrors()
     }
@@ -33,7 +33,7 @@ export default class GitHubFile {
   // Public
   openOnMaster (lineRange) {
     if (this.isOpenable()) {
-      this.openUrlInBrowser(this.blobUrlForMaster() + this.getLineRangeSuffix(lineRange))
+      this.openURLInBrowser(this.blobURLForMaster() + this.getLineRangeSuffix(lineRange))
     } else {
       this.reportValidationErrors()
     }
@@ -42,7 +42,7 @@ export default class GitHubFile {
   // Public
   blame (lineRange) {
     if (this.isOpenable()) {
-      this.openUrlInBrowser(this.blameUrl() + this.getLineRangeSuffix(lineRange))
+      this.openURLInBrowser(this.blameURL() + this.getLineRangeSuffix(lineRange))
     } else {
       this.reportValidationErrors()
     }
@@ -50,15 +50,15 @@ export default class GitHubFile {
 
   history () {
     if (this.isOpenable()) {
-      this.openUrlInBrowser(this.historyUrl())
+      this.openURLInBrowser(this.historyURL())
     } else {
       this.reportValidationErrors()
     }
   }
 
-  copyUrl (lineRange) {
+  copyURL (lineRange) {
     if (this.isOpenable()) {
-      atom.clipboard.write(this.shaUrl() + this.getLineRangeSuffix(lineRange))
+      atom.clipboard.write(this.shaURL() + this.getLineRangeSuffix(lineRange))
     } else {
       this.reportValidationErrors()
     }
@@ -66,7 +66,7 @@ export default class GitHubFile {
 
   openBranchCompare () {
     if (this.isOpenable()) {
-      this.openUrlInBrowser(this.branchCompareUrl())
+      this.openURLInBrowser(this.branchCompareURL())
     } else {
       this.reportValidationErrors()
     }
@@ -74,7 +74,7 @@ export default class GitHubFile {
 
   openIssues () {
     if (this.isOpenable()) {
-      this.openUrlInBrowser(this.issuesUrl())
+      this.openURLInBrowser(this.issuesURL())
     } else {
       this.reportValidationErrors()
     }
@@ -82,7 +82,7 @@ export default class GitHubFile {
 
   openPullRequests () {
     if (this.isOpenable()) {
-      this.openUrlInBrowser(this.pullRequestsUrl())
+      this.openURLInBrowser(this.pullRequestsURL())
     } else {
       this.reportValidationErrors()
     }
@@ -90,7 +90,7 @@ export default class GitHubFile {
 
   openRepository () {
     if (this.isOpenable()) {
-      this.openUrlInBrowser(this.githubRepoUrl())
+      this.openURLInBrowser(this.githubRepoURL())
     } else {
       this.reportValidationErrors()
     }
@@ -100,7 +100,7 @@ export default class GitHubFile {
     let endRow
     let startRow
 
-    if (lineRange && atom.config.get('open-on-github.includeLineNumbersInUrls')) {
+    if (lineRange && atom.config.get('open-on-github.includeLineNumbersInURLs')) {
       lineRange = Range.fromObject(lineRange)
       startRow = lineRange.start.row + 1
       endRow = lineRange.end.row + 1
@@ -126,12 +126,12 @@ export default class GitHubFile {
       return [`No repository found for path: ${this.filePath}.`]
     }
 
-    if (!this.gitUrl()) {
+    if (!this.gitURL()) {
       return [`No URL defined for remote: ${this.remoteName()}`]
     }
 
-    if (!this.githubRepoUrl()) {
-      return [`Remote URL is not hosted on GitHub: ${this.gitUrl()}`]
+    if (!this.githubRepoURL()) {
+      return [`Remote URL is not hosted on GitHub: ${this.gitURL()}`]
     }
 
     return []
@@ -144,56 +144,56 @@ export default class GitHubFile {
   }
 
   // Internal
-  openUrlInBrowser (url) {
+  openURLInBrowser (url) {
     shell.openExternal(url)
   }
 
   // Internal
-  blobUrl () {
-    const gitHubRepoUrl = this.githubRepoUrl()
+  blobURL () {
+    const gitHubRepoURL = this.githubRepoURL()
     const remoteBranchName = this.remoteBranchName()
     const repoRelativePath = this.repoRelativePath()
 
-    if (this.isGitHubWikiUrl(gitHubRepoUrl)) {
-      return `${gitHubRepoUrl.slice(0, -5)}/wiki/${this.extractFileName(repoRelativePath)}`
+    if (this.isGitHubWikiURL(gitHubRepoURL)) {
+      return `${gitHubRepoURL.slice(0, -5)}/wiki/${this.extractFileName(repoRelativePath)}`
     } else {
-      return `${gitHubRepoUrl}/blob/${remoteBranchName}/${this.encodeSegments(repoRelativePath)}`
+      return `${gitHubRepoURL}/blob/${remoteBranchName}/${this.encodeSegments(repoRelativePath)}`
     }
   }
 
   // Internal
-  blobUrlForMaster () {
-    return `${this.githubRepoUrl()}/blob/master/${this.encodeSegments(this.repoRelativePath())}`
+  blobURLForMaster () {
+    return `${this.githubRepoURL()}/blob/master/${this.encodeSegments(this.repoRelativePath())}`
   }
 
   // Internal
-  shaUrl () {
-    return `${this.githubRepoUrl()}/blob/${this.encodeSegments(this.sha())}/${this.encodeSegments(this.repoRelativePath())}`
+  shaURL () {
+    return `${this.githubRepoURL()}/blob/${this.encodeSegments(this.sha())}/${this.encodeSegments(this.repoRelativePath())}`
   }
 
   // Internal
-  blameUrl () {
-    return `${this.githubRepoUrl()}/blame/${this.remoteBranchName()}/${this.encodeSegments(this.repoRelativePath())}`
+  blameURL () {
+    return `${this.githubRepoURL()}/blame/${this.remoteBranchName()}/${this.encodeSegments(this.repoRelativePath())}`
   }
 
   // Internal
-  historyUrl () {
-    return `${this.githubRepoUrl()}/commits/${this.remoteBranchName()}/${this.encodeSegments(this.repoRelativePath())}`
+  historyURL () {
+    return `${this.githubRepoURL()}/commits/${this.remoteBranchName()}/${this.encodeSegments(this.repoRelativePath())}`
   }
 
   // Internal
-  issuesUrl () {
-    return `${this.githubRepoUrl()}/issues`
+  issuesURL () {
+    return `${this.githubRepoURL()}/issues`
   }
 
   // Internal
-  pullRequestsUrl () {
-    return `${this.githubRepoUrl()}/pulls`
+  pullRequestsURL () {
+    return `${this.githubRepoURL()}/pulls`
   }
 
   // Internal
-  branchCompareUrl () {
-    return `${this.githubRepoUrl()}/compare/${this.encodeSegments(this.branchName())}`
+  branchCompareURL () {
+    return `${this.githubRepoURL()}/compare/${this.encodeSegments(this.branchName())}`
   }
 
   encodeSegments (segments = '') {
@@ -206,7 +206,7 @@ export default class GitHubFile {
   }
 
   // Internal
-  gitUrl () {
+  gitURL () {
     const remoteName = this.remoteName()
     if (remoteName != null) {
       return this.repo.getConfigValue(`remote.${remoteName}.url`, this.filePath)
@@ -216,8 +216,8 @@ export default class GitHubFile {
   }
 
   // Internal
-  githubRepoUrl () {
-    let url = this.gitUrl()
+  githubRepoURL () {
+    let url = this.gitURL()
 
     if (url.match(/git@[^:]+:/)) {
       url = url.replace(/^git@([^:]+):(.+)$/, (match, host, repoPath) => {
@@ -233,22 +233,22 @@ export default class GitHubFile {
     // Remove trailing .git and trailing slashes
     url = url.replace(/\.git$/, '').replace(/\/+$/, '')
 
-    if (!this.isBitbucketUrl(url)) {
+    if (!this.isBitbucketURL(url)) {
       return url
     }
   }
 
-  isGitHubWikiUrl (url) {
+  isGitHubWikiURL (url) {
     return /\.wiki$/.test(url)
   }
 
-  isBitbucketUrl (url) {
+  isBitbucketURL (url) {
     if (url.indexOf('git@bitbucket.org') === 0) {
       return true
     }
 
     try {
-      let {host} = parseUrl(url)
+      let {host} = parseURL(url)
 
       return host === 'bitbucket.org'
     } finally {}

--- a/lib/github-file.js
+++ b/lib/github-file.js
@@ -23,76 +23,58 @@ export default class GitHubFile {
 
   // Public
   open (lineRange) {
-    if (this.isOpenable()) {
+    if (this.validateRepo()) {
       this.openURLInBrowser(this.blobURL() + this.getLineRangeSuffix(lineRange))
-    } else {
-      this.reportValidationErrors()
     }
   }
 
   // Public
   openOnMaster (lineRange) {
-    if (this.isOpenable()) {
+    if (this.validateRepo()) {
       this.openURLInBrowser(this.blobURLForMaster() + this.getLineRangeSuffix(lineRange))
-    } else {
-      this.reportValidationErrors()
     }
   }
 
   // Public
   blame (lineRange) {
-    if (this.isOpenable()) {
+    if (this.validateRepo()) {
       this.openURLInBrowser(this.blameURL() + this.getLineRangeSuffix(lineRange))
-    } else {
-      this.reportValidationErrors()
     }
   }
 
   history () {
-    if (this.isOpenable()) {
+    if (this.validateRepo()) {
       this.openURLInBrowser(this.historyURL())
-    } else {
-      this.reportValidationErrors()
     }
   }
 
   copyURL (lineRange) {
-    if (this.isOpenable()) {
+    if (this.validateRepo()) {
       atom.clipboard.write(this.shaURL() + this.getLineRangeSuffix(lineRange))
-    } else {
-      this.reportValidationErrors()
     }
   }
 
   openBranchCompare () {
-    if (this.isOpenable()) {
+    if (this.validateRepo()) {
       this.openURLInBrowser(this.branchCompareURL())
-    } else {
-      this.reportValidationErrors()
     }
   }
 
   openIssues () {
-    if (this.isOpenable()) {
+    if (this.validateRepo()) {
       this.openURLInBrowser(this.issuesURL())
-    } else {
-      this.reportValidationErrors()
     }
   }
 
   openPullRequests () {
-    if (this.isOpenable()) {
+    if (this.validateRepo()) {
       this.openURLInBrowser(this.pullRequestsURL())
-    } else {
-      this.reportValidationErrors()
     }
   }
 
   openRepository () {
-    if (this.isOpenable()) {
+    if (this.validateRepo()) {
       this.openURLInBrowser(this.githubRepoURL())
-    } else {
-      this.reportValidationErrors()
     }
   }
 
@@ -115,32 +97,19 @@ export default class GitHubFile {
     }
   }
 
-  // Public
-  isOpenable () {
-    return this.validationErrors().length === 0
-  }
-
-  // Public
-  validationErrors () {
-    if (!this.repo) {
-      return [`No repository found for path: ${this.filePath}.`]
-    }
-
-    if (!this.gitURL()) {
-      return [`No URL defined for remote: ${this.remoteName()}`]
-    }
-
-    if (!this.githubRepoURL()) {
-      return [`Remote URL is not hosted on GitHub: ${this.gitURL()}`]
-    }
-
-    return []
-  }
-
   // Internal
-  reportValidationErrors () {
-    const message = this.validationErrors().join('\n')
-    atom.notifications.addWarning(message)
+  validateRepo () {
+    if (!this.repo) {
+      atom.notifications.addWarning(`No repository found for path: ${this.filePath}.`)
+      return false
+    } else if (!this.gitURL()) {
+      atom.notifications.addWarning(`No URL defined for remote: ${this.remoteName()}`)
+      return false
+    } else if (!this.githubRepoURL()) {
+      atom.notifications.addWarning(`Remote URL is not hosted on GitHub: ${this.gitURL()}`)
+      return false
+    }
+    return true
   }
 
   // Internal

--- a/lib/github-file.js
+++ b/lib/github-file.js
@@ -79,13 +79,10 @@ export default class GitHubFile {
   }
 
   getLineRangeSuffix (lineRange) {
-    let endRow
-    let startRow
-
     if (lineRange && atom.config.get('open-on-github.includeLineNumbersInURLs')) {
       lineRange = Range.fromObject(lineRange)
-      startRow = lineRange.start.row + 1
-      endRow = lineRange.end.row + 1
+      const startRow = lineRange.start.row + 1
+      const endRow = lineRange.end.row + 1
 
       if (startRow === endRow) {
         return `#L${startRow}`
@@ -212,7 +209,7 @@ export default class GitHubFile {
   }
 
   isBitbucketURL (url) {
-    if (url.indexOf('git@bitbucket.org') === 0) {
+    if (url.startsWith('git@bitbucket.org')) {
       return true
     }
 

--- a/spec/github-file-spec.js
+++ b/spec/github-file-spec.js
@@ -45,17 +45,17 @@ describe('GitHubFile', function () {
         })
 
         it('opens the GitHub.com blob URL for the file', () => {
-          spyOn(githubFile, 'openUrlInBrowser')
+          spyOn(githubFile, 'openURLInBrowser')
           githubFile.open()
-          expect(githubFile.openUrlInBrowser).toHaveBeenCalledWith('https://github.com/some-user/some-repo/blob/master/some-dir/some-file.md')
+          expect(githubFile.openURLInBrowser).toHaveBeenCalledWith('https://github.com/some-user/some-repo/blob/master/some-dir/some-file.md')
         })
 
         describe('when text is selected', () => {
           it('opens the GitHub.com blob URL for the file with the selection range in the hash', () => {
-            atom.config.set('open-on-github.includeLineNumbersInUrls', true)
-            spyOn(githubFile, 'openUrlInBrowser')
+            atom.config.set('open-on-github.includeLineNumbersInURLs', true)
+            spyOn(githubFile, 'openURLInBrowser')
             githubFile.open([[0, 0], [1, 1]])
-            expect(githubFile.openUrlInBrowser).toHaveBeenCalledWith('https://github.com/some-user/some-repo/blob/master/some-dir/some-file.md#L1-L2')
+            expect(githubFile.openURLInBrowser).toHaveBeenCalledWith('https://github.com/some-user/some-repo/blob/master/some-dir/some-file.md#L1-L2')
           })
         })
 
@@ -63,9 +63,9 @@ describe('GitHubFile', function () {
           it('opens the GitHub.com blob URL for the file', async () => {
             editor = await atom.workspace.open('a/b#/test#hash.md')
             githubFile = GitHubFile.fromPath(editor.getPath())
-            spyOn(githubFile, 'openUrlInBrowser')
+            spyOn(githubFile, 'openURLInBrowser')
             githubFile.open()
-            expect(githubFile.openUrlInBrowser).toHaveBeenCalledWith('https://github.com/some-user/some-repo/blob/master/a/b%23/test%23hash.md')
+            expect(githubFile.openURLInBrowser).toHaveBeenCalledWith('https://github.com/some-user/some-repo/blob/master/a/b%23/test%23hash.md')
           })
         })
       })
@@ -79,10 +79,10 @@ describe('GitHubFile', function () {
         })
 
         it('opens the GitHub.com wiki URL for the file', () => {
-          spyOn(githubFile, 'openUrlInBrowser')
+          spyOn(githubFile, 'openURLInBrowser')
           githubFile.open()
           runs(() => {
-            expect(githubFile.openUrlInBrowser).toHaveBeenCalledWith('https://github.com/some-user/some-repo/wiki/some-file')
+            expect(githubFile.openURLInBrowser).toHaveBeenCalledWith('https://github.com/some-user/some-repo/wiki/some-file')
           })
         })
       })
@@ -96,9 +96,9 @@ describe('GitHubFile', function () {
         })
 
         it('opens the GitHub.com blob URL for the file', () => {
-          spyOn(githubFile, 'openUrlInBrowser')
+          spyOn(githubFile, 'openURLInBrowser')
           githubFile.open()
-          expect(githubFile.openUrlInBrowser).toHaveBeenCalledWith('https://github.com/some-user/some-repo/blob/foo/bar/some-dir/some-file.md')
+          expect(githubFile.openURLInBrowser).toHaveBeenCalledWith('https://github.com/some-user/some-repo/blob/foo/bar/some-dir/some-file.md')
         })
       })
 
@@ -111,9 +111,9 @@ describe('GitHubFile', function () {
         })
 
         it('opens the GitHub.com blob URL for the file', () => {
-          spyOn(githubFile, 'openUrlInBrowser')
+          spyOn(githubFile, 'openURLInBrowser')
           githubFile.open()
-          expect(githubFile.openUrlInBrowser).toHaveBeenCalledWith('https://github.com/some-user/some-repo/blob/a%23b%23c/some-dir/some-file.md')
+          expect(githubFile.openURLInBrowser).toHaveBeenCalledWith('https://github.com/some-user/some-repo/blob/a%23b%23c/some-dir/some-file.md')
         })
       })
 
@@ -126,9 +126,9 @@ describe('GitHubFile', function () {
         })
 
         it('opens the GitHub.com blob URL for the file', () => {
-          spyOn(githubFile, 'openUrlInBrowser')
+          spyOn(githubFile, 'openURLInBrowser')
           githubFile.open()
-          expect(githubFile.openUrlInBrowser).toHaveBeenCalledWith('https://github.com/some-user/some-repo/blob/baz/some-dir/some-file.md')
+          expect(githubFile.openURLInBrowser).toHaveBeenCalledWith('https://github.com/some-user/some-repo/blob/baz/some-dir/some-file.md')
         })
       })
 
@@ -141,9 +141,9 @@ describe('GitHubFile', function () {
         })
 
         it('opens the GitHub.com blob URL for the file on the master branch', () => {
-          spyOn(githubFile, 'openUrlInBrowser')
+          spyOn(githubFile, 'openURLInBrowser')
           githubFile.open()
-          expect(githubFile.openUrlInBrowser).toHaveBeenCalledWith('https://github.com/some-user/some-repo/blob/master/some-dir/some-file.md')
+          expect(githubFile.openURLInBrowser).toHaveBeenCalledWith('https://github.com/some-user/some-repo/blob/master/some-dir/some-file.md')
         })
       })
 
@@ -185,9 +185,9 @@ describe('GitHubFile', function () {
         })
 
         it('opens a GitHub enterprise style blob URL for the file', () => {
-          spyOn(githubFile, 'openUrlInBrowser')
+          spyOn(githubFile, 'openURLInBrowser')
           githubFile.open()
-          expect(githubFile.openUrlInBrowser).toHaveBeenCalledWith('https://git.enterprize.me/some-user/some-repo/blob/master/some-dir/some-file.md')
+          expect(githubFile.openURLInBrowser).toHaveBeenCalledWith('https://git.enterprize.me/some-user/some-repo/blob/master/some-dir/some-file.md')
         })
       })
 
@@ -200,9 +200,9 @@ describe('GitHubFile', function () {
         })
 
         it('opens a URL that is specified by the git config', () => {
-          spyOn(githubFile, 'openUrlInBrowser')
+          spyOn(githubFile, 'openURLInBrowser')
           githubFile.open()
-          expect(githubFile.openUrlInBrowser).toHaveBeenCalledWith('https://github.com/foo/bar/blob/some-branch/some-dir/some-file.md')
+          expect(githubFile.openURLInBrowser).toHaveBeenCalledWith('https://github.com/foo/bar/blob/some-branch/some-dir/some-file.md')
         })
       })
     })
@@ -216,9 +216,9 @@ describe('GitHubFile', function () {
       })
 
       it('opens the GitHub.com blob URL for the file', () => {
-        spyOn(githubFile, 'openUrlInBrowser')
+        spyOn(githubFile, 'openURLInBrowser')
         githubFile.openOnMaster()
-        expect(githubFile.openUrlInBrowser).toHaveBeenCalledWith('https://github.com/some-user/some-repo/blob/master/some-dir/some-file.md')
+        expect(githubFile.openURLInBrowser).toHaveBeenCalledWith('https://github.com/some-user/some-repo/blob/master/some-dir/some-file.md')
       })
     })
 
@@ -232,17 +232,17 @@ describe('GitHubFile', function () {
         })
 
         it('opens the GitHub.com blame URL for the file', () => {
-          spyOn(githubFile, 'openUrlInBrowser')
+          spyOn(githubFile, 'openURLInBrowser')
           githubFile.blame()
-          expect(githubFile.openUrlInBrowser).toHaveBeenCalledWith('https://github.com/some-user/some-repo/blame/master/some-dir/some-file.md')
+          expect(githubFile.openURLInBrowser).toHaveBeenCalledWith('https://github.com/some-user/some-repo/blame/master/some-dir/some-file.md')
         })
 
         describe('when text is selected', () => {
           it('opens the GitHub.com blame URL for the file with the selection range in the hash', () => {
-            atom.config.set('open-on-github.includeLineNumbersInUrls', true)
-            spyOn(githubFile, 'openUrlInBrowser')
+            atom.config.set('open-on-github.includeLineNumbersInURLs', true)
+            spyOn(githubFile, 'openURLInBrowser')
             githubFile.blame([[0, 0], [1, 1]])
-            expect(githubFile.openUrlInBrowser).toHaveBeenCalledWith('https://github.com/some-user/some-repo/blame/master/some-dir/some-file.md#L1-L2')
+            expect(githubFile.openURLInBrowser).toHaveBeenCalledWith('https://github.com/some-user/some-repo/blame/master/some-dir/some-file.md#L1-L2')
           })
         })
       })
@@ -256,9 +256,9 @@ describe('GitHubFile', function () {
         })
 
         it('opens the GitHub.com blame URL for the file on the master branch', () => {
-          spyOn(githubFile, 'openUrlInBrowser')
+          spyOn(githubFile, 'openURLInBrowser')
           githubFile.blame()
-          expect(githubFile.openUrlInBrowser).toHaveBeenCalledWith('https://github.com/some-user/some-repo/blame/master/some-dir/some-file.md')
+          expect(githubFile.openURLInBrowser).toHaveBeenCalledWith('https://github.com/some-user/some-repo/blame/master/some-dir/some-file.md')
         })
       })
     })
@@ -273,9 +273,9 @@ describe('GitHubFile', function () {
         })
 
         it('opens the GitHub.com branch compare URL for the file', () => {
-          spyOn(githubFile, 'openUrlInBrowser')
+          spyOn(githubFile, 'openURLInBrowser')
           githubFile.openBranchCompare()
-          expect(githubFile.openUrlInBrowser).toHaveBeenCalledWith('https://github.com/some-user/some-repo/compare/master')
+          expect(githubFile.openURLInBrowser).toHaveBeenCalledWith('https://github.com/some-user/some-repo/compare/master')
         })
       })
     })
@@ -290,9 +290,9 @@ describe('GitHubFile', function () {
         })
 
         it('opens the GitHub.com history URL for the file', () => {
-          spyOn(githubFile, 'openUrlInBrowser')
+          spyOn(githubFile, 'openURLInBrowser')
           githubFile.history()
-          expect(githubFile.openUrlInBrowser).toHaveBeenCalledWith('https://github.com/some-user/some-repo/commits/master/some-dir/some-file.md')
+          expect(githubFile.openURLInBrowser).toHaveBeenCalledWith('https://github.com/some-user/some-repo/commits/master/some-dir/some-file.md')
         })
       })
 
@@ -305,32 +305,32 @@ describe('GitHubFile', function () {
         })
 
         it('opens the GitHub.com history URL for the file on the master branch', () => {
-          spyOn(githubFile, 'openUrlInBrowser')
+          spyOn(githubFile, 'openURLInBrowser')
           githubFile.history()
-          expect(githubFile.openUrlInBrowser).toHaveBeenCalledWith('https://github.com/some-user/some-repo/commits/master/some-dir/some-file.md')
+          expect(githubFile.openURLInBrowser).toHaveBeenCalledWith('https://github.com/some-user/some-repo/commits/master/some-dir/some-file.md')
         })
       })
     })
 
-    describe('copyUrl', () => {
+    describe('copyURL', () => {
       let fixtureName = 'github-remote'
 
       beforeEach(async () => {
         setupWorkingDir(fixtureName)
-        atom.config.set('open-on-github.includeLineNumbersInUrls', true)
+        atom.config.set('open-on-github.includeLineNumbersInURLs', true)
         await setupGithubFile()
       })
 
       describe('when text is selected', () => {
         it('copies the URL to the clipboard with the selection range in the hash', () => {
-          githubFile.copyUrl([[0, 0], [1, 1]])
+          githubFile.copyURL([[0, 0], [1, 1]])
           expect(atom.clipboard.read()).toBe('https://github.com/some-user/some-repo/blob/80b7897ceb6bd7531708509b50afeab36a4b73fd/some-dir/some-file.md#L1-L2')
         })
       })
 
       describe('when no text is selected', () => {
         it('copies the URL to the clipboard with the cursor location in the hash', () => {
-          githubFile.copyUrl([[2, 1], [2, 1]])
+          githubFile.copyURL([[2, 1], [2, 1]])
           return expect(atom.clipboard.read()).toBe('https://github.com/some-user/some-repo/blob/80b7897ceb6bd7531708509b50afeab36a4b73fd/some-dir/some-file.md#L3')
         })
       })
@@ -346,9 +346,9 @@ describe('GitHubFile', function () {
         })
 
         it('opens the GitHub.com repository URL', () => {
-          spyOn(githubFile, 'openUrlInBrowser')
+          spyOn(githubFile, 'openURLInBrowser')
           githubFile.openRepository()
-          expect(githubFile.openUrlInBrowser).toHaveBeenCalledWith('https://github.com/some-user/some-repo')
+          expect(githubFile.openURLInBrowser).toHaveBeenCalledWith('https://github.com/some-user/some-repo')
         })
       })
     })
@@ -363,9 +363,9 @@ describe('GitHubFile', function () {
         })
 
         it('opens the GitHub.com issues URL', () => {
-          spyOn(githubFile, 'openUrlInBrowser')
+          spyOn(githubFile, 'openURLInBrowser')
           githubFile.openIssues()
-          expect(githubFile.openUrlInBrowser).toHaveBeenCalledWith('https://github.com/some-user/some-repo/issues')
+          expect(githubFile.openURLInBrowser).toHaveBeenCalledWith('https://github.com/some-user/some-repo/issues')
         })
       })
     })
@@ -380,83 +380,83 @@ describe('GitHubFile', function () {
         })
 
         it('opens the GitHub.com pull requests URL', () => {
-          spyOn(githubFile, 'openUrlInBrowser')
+          spyOn(githubFile, 'openURLInBrowser')
           githubFile.openPullRequests()
-          expect(githubFile.openUrlInBrowser).toHaveBeenCalledWith('https://github.com/some-user/some-repo/pulls')
+          expect(githubFile.openURLInBrowser).toHaveBeenCalledWith('https://github.com/some-user/some-repo/pulls')
         })
       })
     })
   })
 
-  describe('githubRepoUrl', () => {
+  describe('githubRepoURL', () => {
     beforeEach(() => {
       githubFile = new GitHubFile()
     })
 
     it('returns the GitHub.com URL for an HTTPS remote URL', () => {
-      githubFile.gitUrl = () => 'https://github.com/foo/bar.git'
-      expect(githubFile.githubRepoUrl()).toBe('https://github.com/foo/bar')
+      githubFile.gitURL = () => 'https://github.com/foo/bar.git'
+      expect(githubFile.githubRepoURL()).toBe('https://github.com/foo/bar')
     })
 
     it('will only strip a single .git suffix', () => {
-      githubFile.gitUrl = () => 'https://github.com/foo/bar.git.git'
-      expect(githubFile.githubRepoUrl()).toBe('https://github.com/foo/bar.git')
+      githubFile.gitURL = () => 'https://github.com/foo/bar.git.git'
+      expect(githubFile.githubRepoURL()).toBe('https://github.com/foo/bar.git')
 
-      githubFile.gitUrl = () => 'https://github.com/foo/bar.git.other.git'
-      expect(githubFile.githubRepoUrl()).toBe('https://github.com/foo/bar.git.other')
+      githubFile.gitURL = () => 'https://github.com/foo/bar.git.other.git'
+      expect(githubFile.githubRepoURL()).toBe('https://github.com/foo/bar.git.other')
     })
 
     it('returns the GitHub.com URL for an HTTP remote URL', () => {
-      githubFile.gitUrl = () => 'http://github.com/foo/bar.git'
-      expect(githubFile.githubRepoUrl()).toBe('http://github.com/foo/bar')
+      githubFile.gitURL = () => 'http://github.com/foo/bar.git'
+      expect(githubFile.githubRepoURL()).toBe('http://github.com/foo/bar')
     })
 
     it('returns the GitHub.com URL for an SSH remote URL', () => {
-      githubFile.gitUrl = () => 'git@github.com:foo/bar.git'
-      expect(githubFile.githubRepoUrl()).toBe('http://github.com/foo/bar')
+      githubFile.gitURL = () => 'git@github.com:foo/bar.git'
+      expect(githubFile.githubRepoURL()).toBe('http://github.com/foo/bar')
     })
 
     it('returns a GitHub enterprise URL for a non-Github.com remote URL', () => {
-      githubFile.gitUrl = () => 'https://git.enterprize.me/foo/bar.git'
-      expect(githubFile.githubRepoUrl()).toBe('https://git.enterprize.me/foo/bar')
+      githubFile.gitURL = () => 'https://git.enterprize.me/foo/bar.git'
+      expect(githubFile.githubRepoURL()).toBe('https://git.enterprize.me/foo/bar')
 
-      githubFile.gitUrl = () => 'git@git.enterprize.me:foo/bar.git'
-      expect(githubFile.githubRepoUrl()).toBe('http://git.enterprize.me/foo/bar')
+      githubFile.gitURL = () => 'git@git.enterprize.me:foo/bar.git'
+      expect(githubFile.githubRepoURL()).toBe('http://git.enterprize.me/foo/bar')
     })
 
     it('returns the GitHub.com URL for a git:// URL', () => {
-      githubFile.gitUrl = () => 'git://github.com/foo/bar.git'
-      expect(githubFile.githubRepoUrl()).toBe('http://github.com/foo/bar')
+      githubFile.gitURL = () => 'git://github.com/foo/bar.git'
+      expect(githubFile.githubRepoURL()).toBe('http://github.com/foo/bar')
     })
 
     it('returns the GitHub.com URL for a ssh:// URL', () => {
-      githubFile.gitUrl = () => 'ssh://git@github.com/foo/bar.git'
-      expect(githubFile.githubRepoUrl()).toBe('http://github.com/foo/bar')
+      githubFile.gitURL = () => 'ssh://git@github.com/foo/bar.git'
+      expect(githubFile.githubRepoURL()).toBe('http://github.com/foo/bar')
     })
 
     it('returns undefined for Bitbucket URLs', () => {
-      githubFile.gitUrl = () => 'https://bitbucket.org/somebody/repo.git'
-      expect(githubFile.githubRepoUrl()).toBeUndefined()
+      githubFile.gitURL = () => 'https://bitbucket.org/somebody/repo.git'
+      expect(githubFile.githubRepoURL()).toBeUndefined()
 
-      githubFile.gitUrl = () => 'https://bitbucket.org/somebody/repo'
-      expect(githubFile.githubRepoUrl()).toBeUndefined()
+      githubFile.gitURL = () => 'https://bitbucket.org/somebody/repo'
+      expect(githubFile.githubRepoURL()).toBeUndefined()
 
-      githubFile.gitUrl = () => 'git@bitbucket.org:somebody/repo.git'
-      expect(githubFile.githubRepoUrl()).toBeUndefined()
+      githubFile.gitURL = () => 'git@bitbucket.org:somebody/repo.git'
+      expect(githubFile.githubRepoURL()).toBeUndefined()
 
-      githubFile.gitUrl = () => 'git@bitbucket.org:somebody/repo'
-      expect(githubFile.githubRepoUrl()).toBeUndefined()
+      githubFile.gitURL = () => 'git@bitbucket.org:somebody/repo'
+      expect(githubFile.githubRepoURL()).toBeUndefined()
     })
 
     it('removes leading and trailing slashes', () => {
-      githubFile.gitUrl = () => 'https://github.com/foo/bar/'
-      expect(githubFile.githubRepoUrl()).toBe('https://github.com/foo/bar')
+      githubFile.gitURL = () => 'https://github.com/foo/bar/'
+      expect(githubFile.githubRepoURL()).toBe('https://github.com/foo/bar')
 
-      githubFile.gitUrl = () => 'https://github.com/foo/bar//////'
-      expect(githubFile.githubRepoUrl()).toBe('https://github.com/foo/bar')
+      githubFile.gitURL = () => 'https://github.com/foo/bar//////'
+      expect(githubFile.githubRepoURL()).toBe('https://github.com/foo/bar')
 
-      githubFile.gitUrl = () => 'git@github.com:/foo/bar.git'
-      expect(githubFile.githubRepoUrl()).toBe('http://github.com/foo/bar')
+      githubFile.gitURL = () => 'git@github.com:/foo/bar.git'
+      expect(githubFile.githubRepoURL()).toBe('http://github.com/foo/bar')
     })
   })
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

* Rework error validation: previously it was expected that an array of errors would be returned, when in reality only one error would ever be returned.  So just switch it to expect a String and also report errors when validating the repo.
* let -> const where possible
* Url -> URL
* Some other minor changes

### Alternate Designs

None.

### Benefits

Just a bit of code maintenance.  Error reporting should be clearer.

### Possible Drawbacks

Not sure what the Public and Internal docs mean in this file, since we don't export a service or anything.  Therefore I think it's safe to remove the existing error methods and add `validateRepo` as private.  Did a quick search and does not look like anything is relying on those.

### Applicable Issues

None.