### PR TITLE
Add better support for wikis

### DIFF
--- a/lib/github-file.js
+++ b/lib/github-file.js
@@ -79,7 +79,7 @@ export default class GitHubFile {
   }
 
   getLineRangeSuffix (lineRange) {
-    if (lineRange && atom.config.get('open-on-github.includeLineNumbersInUrls')) {
+    if (lineRange && !this.isGitHubWikiURL(this.githubRepoURL()) && atom.config.get('open-on-github.includeLineNumbersInUrls')) {
       lineRange = Range.fromObject(lineRange)
       const startRow = lineRange.start.row + 1
       const endRow = lineRange.end.row + 1

--- a/lib/github-file.js
+++ b/lib/github-file.js
@@ -138,10 +138,12 @@ export default class GitHubFile {
 
   // Internal
   blobURLForMaster () {
-    if (this.isGistURL(this.githubRepoURL())) {
+    const gitHubRepoURL = this.githubRepoURL()
+
+    if (this.isGitHubWikiURL(gitHubRepoURL) || this.isGistURL(gitHubRepoURL)) {
       return this.blobURL() // Gists do not have branches
     } else {
-      return `${this.githubRepoURL()}/blob/master/${this.encodeSegments(this.repoRelativePath())}`
+      return `${gitHubRepoURL}/blob/master/${this.encodeSegments(this.repoRelativePath())}`
     }
   }
 

--- a/lib/github-file.js
+++ b/lib/github-file.js
@@ -128,7 +128,7 @@ export default class GitHubFile {
     const repoRelativePath = this.repoRelativePath()
 
     if (this.isGitHubWikiURL(gitHubRepoURL)) {
-      return `${gitHubRepoURL.slice(0, -5)}/wiki/${this.extractFileName(repoRelativePath)}`
+      return `${gitHubRepoURL}/${this.extractFileName(repoRelativePath)}`
     } else if (this.isGistURL(gitHubRepoURL)) {
       return `${gitHubRepoURL}#file-${this.encodeSegments(repoRelativePath.replace(/\./g, '-'))}`
     } else {
@@ -154,7 +154,7 @@ export default class GitHubFile {
     const repoRelativePath = this.repoRelativePath()
 
     if (this.isGitHubWikiURL(gitHubRepoURL)) {
-      return `${gitHubRepoURL.slice(0, -5)}/wiki/${this.extractFileName(repoRelativePath)}/${encodedSHA}`
+      return `${gitHubRepoURL}/${this.extractFileName(repoRelativePath)}/${encodedSHA}`
     } else if (this.isGistURL(gitHubRepoURL)) {
       return `${gitHubRepoURL}/${encodedSHA}#file-${this.encodeSegments(repoRelativePath.replace(/\./g, '-'))}`
     } else {
@@ -172,7 +172,7 @@ export default class GitHubFile {
     const gitHubRepoURL = this.githubRepoURL()
 
     if (this.isGitHubWikiURL(gitHubRepoURL)) {
-      return `${gitHubRepoURL.slice(0, -5)}/wiki/${this.extractFileName(this.repoRelativePath())}/_history`
+      return `${gitHubRepoURL}/${this.extractFileName(this.repoRelativePath())}/_history`
     } else if (this.isGistURL(gitHubRepoURL)) {
       return `${gitHubRepoURL}/revisions`
     } else {
@@ -231,6 +231,8 @@ export default class GitHubFile {
 
     // Remove trailing .git and trailing slashes
     url = url.replace(/\.git$/, '').replace(/\/+$/, '')
+    // Change .wiki to /wiki
+    url = url.replace(/\.wiki$/, '/wiki')
 
     if (!this.isBitbucketURL(url)) {
       return url
@@ -246,7 +248,7 @@ export default class GitHubFile {
   }
 
   isGitHubWikiURL (url) {
-    return /\.wiki$/.test(url)
+    return /\/wiki$/.test(url)
   }
 
   isBitbucketURL (url) {

--- a/lib/github-file.js
+++ b/lib/github-file.js
@@ -153,7 +153,9 @@ export default class GitHubFile {
     const encodedSHA = this.encodeSegments(this.sha())
     const repoRelativePath = this.repoRelativePath()
 
-    if (this.isGistURL(gitHubRepoURL)) {
+    if (this.isGitHubWikiURL(gitHubRepoURL)) {
+      return `${gitHubRepoURL.slice(0, -5)}/wiki/${this.extractFileName(repoRelativePath)}/${encodedSHA}`
+    } else if (this.isGistURL(gitHubRepoURL)) {
       return `${gitHubRepoURL}/${encodedSHA}#file-${this.encodeSegments(repoRelativePath.replace(/\./g, '-'))}`
     } else {
       return `${gitHubRepoURL}/blob/${encodedSHA}/${this.encodeSegments(repoRelativePath)}`

--- a/lib/github-file.js
+++ b/lib/github-file.js
@@ -171,7 +171,9 @@ export default class GitHubFile {
   historyURL () {
     const gitHubRepoURL = this.githubRepoURL()
 
-    if (this.isGistURL(gitHubRepoURL)) {
+    if (this.isGitHubWikiURL(gitHubRepoURL)) {
+      return `${gitHubRepoURL.slice(0, -5)}/wiki/${this.extractFileName(this.repoRelativePath())}/_history`
+    } else if (this.isGistURL(gitHubRepoURL)) {
       return `${gitHubRepoURL}/revisions`
     } else {
       return `${gitHubRepoURL}/commits/${this.remoteBranchName()}/${this.encodeSegments(this.repoRelativePath())}`

--- a/spec/github-file-spec.js
+++ b/spec/github-file-spec.js
@@ -235,6 +235,21 @@ describe('GitHubFile', function () {
         })
       })
 
+      describe('when the file is part of a GitHub wiki', () => {
+        let fixtureName = 'github-remote-wiki'
+
+        beforeEach(async () => {
+          setupWorkingDir(fixtureName)
+          await setupGithubFile()
+        })
+
+        it('opens the GitHub.com wiki URL for the file and behaves exactly like open', () => {
+          spyOn(githubFile, 'openURLInBrowser')
+          githubFile.openOnMaster()
+          expect(githubFile.openURLInBrowser).toHaveBeenCalledWith('https://github.com/some-user/some-repo/wiki/some-file')
+        })
+      })
+
       describe('when the file is part of a GitHub gist', () => {
         let fixtureName = 'github-remote-gist'
 
@@ -340,6 +355,21 @@ describe('GitHubFile', function () {
         })
       })
 
+      describe('when the file is part of a GitHub wiki', () => {
+        let fixtureName = 'github-remote-wiki'
+
+        beforeEach(async () => {
+          setupWorkingDir(fixtureName)
+          await setupGithubFile()
+        })
+
+        it('opens the GitHub.com wiki history URL for the file', () => {
+          spyOn(githubFile, 'openURLInBrowser')
+          githubFile.history()
+          expect(githubFile.openURLInBrowser).toHaveBeenCalledWith('https://github.com/some-user/some-repo/wiki/some-file/_history')
+        })
+      })
+
       describe('when the file is part of a GitHub gist', () => {
         let fixtureName = 'github-remote-gist'
 
@@ -381,6 +411,21 @@ describe('GitHubFile', function () {
         })
       })
 
+      describe('when the file is part of a GitHub wiki', () => {
+        let fixtureName = 'github-remote-wiki'
+
+        beforeEach(async () => {
+          setupWorkingDir(fixtureName)
+          atom.config.set('open-on-github.includeLineNumbersInUrls', true)
+          await setupGithubFile()
+        })
+
+        it('copies the GitHub.com wiki URL to the clipboard and ignores any selection ranges', () => {
+          githubFile.copyURL([[0, 0], [1, 1]])
+          expect(atom.clipboard.read()).toBe('https://github.com/some-user/some-repo/wiki/some-file/80b7897ceb6bd7531708509b50afeab36a4b73fd')
+        })
+      })
+
       describe('when the file is part of a GitHub gist', () => {
         let fixtureName = 'github-remote-gist'
 
@@ -419,6 +464,21 @@ describe('GitHubFile', function () {
           spyOn(githubFile, 'openURLInBrowser')
           githubFile.openRepository()
           expect(githubFile.openURLInBrowser).toHaveBeenCalledWith('https://github.com/some-user/some-repo')
+        })
+      })
+
+      describe('when the file is part of a GitHub wiki', () => {
+        let fixtureName = 'github-remote-wiki'
+
+        beforeEach(async () => {
+          setupWorkingDir(fixtureName)
+          await setupGithubFile()
+        })
+
+        it('opens the GitHub.com wiki history URL for the file', () => {
+          spyOn(githubFile, 'openURLInBrowser')
+          githubFile.openRepository()
+          expect(githubFile.openURLInBrowser).toHaveBeenCalledWith('https://github.com/some-user/some-repo/wiki')
         })
       })
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

The following commands are now supported, in addition to `open-on-github:file`:
* `open-on-github:file-on-master` (alias to `open-on-github:file`)
* `open-on-github:copy-url`
* `open-on-github:history`
* `open-on-github:repository`

In addition, line suffixes are no longer appended for any wiki operations.

### Alternate Designs

None.

### Benefits

More robust wiki support

### Possible Drawbacks

The only potential risky change is changing `getRepoURL()` to normalize git URLs ending in `.wiki` to `/wiki`, though the repo might just end in `.wiki` and not be an actual GitHub wiki.  I don't see this as too big as a problem as `isGitHubWikiURL()` was already doing that test.

### Applicable Issues

None.