### PR TITLE
Show informative warnings for invalid operations

### DIFF
--- a/lib/github-file.js
+++ b/lib/github-file.js
@@ -18,6 +18,16 @@ export default class GitHubFile {
     if (rootDir != null) {
       const rootDirIndex = atom.project.getPaths().indexOf(rootDir)
       this.repo = atom.project.getRepositories()[rootDirIndex]
+      this.type = 'none'
+      if (this.repo && this.gitURL()) {
+        if (this.isGitHubWikiURL(this.githubRepoURL())) {
+          this.type = 'wiki'
+        } else if (this.isGistURL(this.githubRepoURL())) {
+          this.type = 'gist'
+        } else {
+          this.type = 'repo'
+        }
+      }
     }
   }
 
@@ -38,7 +48,11 @@ export default class GitHubFile {
   // Public
   blame (lineRange) {
     if (this.validateRepo()) {
-      this.openURLInBrowser(this.blameURL() + this.getLineRangeSuffix(lineRange))
+      if (this.type === 'repo') {
+        this.openURLInBrowser(this.blameURL() + this.getLineRangeSuffix(lineRange))
+      } else {
+        atom.notifications.addWarning(`Blames do not exist for ${this.type}s`)
+      }
     }
   }
 
@@ -56,19 +70,31 @@ export default class GitHubFile {
 
   openBranchCompare () {
     if (this.validateRepo()) {
-      this.openURLInBrowser(this.branchCompareURL())
+      if (this.type === 'repo') {
+        this.openURLInBrowser(this.branchCompareURL())
+      } else {
+        atom.notifications.addWarning(`Branches do not exist for ${this.type}s`)
+      }
     }
   }
 
   openIssues () {
     if (this.validateRepo()) {
-      this.openURLInBrowser(this.issuesURL())
+      if (this.type === 'repo') {
+        this.openURLInBrowser(this.issuesURL())
+      } else {
+        atom.notifications.addWarning(`Issues do not exist for ${this.type}s`)
+      }
     }
   }
 
   openPullRequests () {
     if (this.validateRepo()) {
-      this.openURLInBrowser(this.pullRequestsURL())
+      if (this.type === 'repo') {
+        this.openURLInBrowser(this.pullRequestsURL())
+      } else {
+        atom.notifications.addWarning(`Pull requests do not exist for ${this.type}s`)
+      }
     }
   }
 
@@ -79,19 +105,19 @@ export default class GitHubFile {
   }
 
   getLineRangeSuffix (lineRange) {
-    if (lineRange && !this.isGitHubWikiURL(this.githubRepoURL()) && atom.config.get('open-on-github.includeLineNumbersInUrls')) {
+    if (lineRange && this.type !== 'wiki' && atom.config.get('open-on-github.includeLineNumbersInUrls')) {
       lineRange = Range.fromObject(lineRange)
       const startRow = lineRange.start.row + 1
       const endRow = lineRange.end.row + 1
 
       if (startRow === endRow) {
-        if (this.isGistURL(this.githubRepoURL())) {
+        if (this.type === 'gist') {
           return `-L${startRow}`
         } else {
           return `#L${startRow}`
         }
       } else {
-        if (this.isGistURL(this.githubRepoURL())) {
+        if (this.type === 'gist') {
           return `-L${startRow}-L${endRow}`
         } else {
           return `#L${startRow}-L${endRow}`
@@ -127,9 +153,9 @@ export default class GitHubFile {
     const gitHubRepoURL = this.githubRepoURL()
     const repoRelativePath = this.repoRelativePath()
 
-    if (this.isGitHubWikiURL(gitHubRepoURL)) {
+    if (this.type === 'wiki') {
       return `${gitHubRepoURL}/${this.extractFileName(repoRelativePath)}`
-    } else if (this.isGistURL(gitHubRepoURL)) {
+    } else if (this.type === 'gist') {
       return `${gitHubRepoURL}#file-${this.encodeSegments(repoRelativePath.replace(/\./g, '-'))}`
     } else {
       return `${gitHubRepoURL}/blob/${this.remoteBranchName()}/${this.encodeSegments(repoRelativePath)}`
@@ -140,10 +166,10 @@ export default class GitHubFile {
   blobURLForMaster () {
     const gitHubRepoURL = this.githubRepoURL()
 
-    if (this.isGitHubWikiURL(gitHubRepoURL) || this.isGistURL(gitHubRepoURL)) {
-      return this.blobURL() // Gists do not have branches
-    } else {
+    if (this.type === 'repo') {
       return `${gitHubRepoURL}/blob/master/${this.encodeSegments(this.repoRelativePath())}`
+    } else {
+      return this.blobURL() // Only repos have branches
     }
   }
 
@@ -153,9 +179,9 @@ export default class GitHubFile {
     const encodedSHA = this.encodeSegments(this.sha())
     const repoRelativePath = this.repoRelativePath()
 
-    if (this.isGitHubWikiURL(gitHubRepoURL)) {
+    if (this.type === 'wiki') {
       return `${gitHubRepoURL}/${this.extractFileName(repoRelativePath)}/${encodedSHA}`
-    } else if (this.isGistURL(gitHubRepoURL)) {
+    } else if (this.type === 'gist') {
       return `${gitHubRepoURL}/${encodedSHA}#file-${this.encodeSegments(repoRelativePath.replace(/\./g, '-'))}`
     } else {
       return `${gitHubRepoURL}/blob/${encodedSHA}/${this.encodeSegments(repoRelativePath)}`
@@ -171,9 +197,9 @@ export default class GitHubFile {
   historyURL () {
     const gitHubRepoURL = this.githubRepoURL()
 
-    if (this.isGitHubWikiURL(gitHubRepoURL)) {
+    if (this.type === 'wiki') {
       return `${gitHubRepoURL}/${this.extractFileName(this.repoRelativePath())}/_history`
-    } else if (this.isGistURL(gitHubRepoURL)) {
+    } else if (this.type === 'gist') {
       return `${gitHubRepoURL}/revisions`
     } else {
       return `${gitHubRepoURL}/commits/${this.remoteBranchName()}/${this.encodeSegments(this.repoRelativePath())}`

--- a/spec/github-file-spec.js
+++ b/spec/github-file-spec.js
@@ -167,7 +167,7 @@ describe('GitHubFile', function () {
           await setupGithubFile()
         })
 
-        it('logs an error', () => {
+        it('shows a warning', () => {
           spyOn(atom.notifications, 'addWarning')
           githubFile.open()
           expect(atom.notifications.addWarning).toHaveBeenCalledWith('No URL defined for remote: null')
@@ -305,6 +305,40 @@ describe('GitHubFile', function () {
           expect(githubFile.openURLInBrowser).toHaveBeenCalledWith('https://github.com/some-user/some-repo/blame/master/some-dir/some-file.md')
         })
       })
+
+      describe('when the file is part of a GitHub wiki', () => {
+        let fixtureName = 'github-remote-wiki'
+
+        beforeEach(async () => {
+          setupWorkingDir(fixtureName)
+          await setupGithubFile()
+        })
+
+        it('shows a warning and does not attempt to open a URL', () => {
+          spyOn(githubFile, 'openURLInBrowser')
+          spyOn(atom.notifications, 'addWarning')
+          githubFile.blame()
+          expect(atom.notifications.addWarning).toHaveBeenCalledWith('Blames do not exist for wikis')
+          expect(githubFile.openURLInBrowser).not.toHaveBeenCalled()
+        })
+      })
+
+      describe('when the file is part of a GitHub wiki', () => {
+        let fixtureName = 'github-remote-gist'
+
+        beforeEach(async () => {
+          setupWorkingDir(fixtureName)
+          await setupGithubFile()
+        })
+
+        it('shows a warning and does not attempt to open a URL', () => {
+          spyOn(githubFile, 'openURLInBrowser')
+          spyOn(atom.notifications, 'addWarning')
+          githubFile.blame()
+          expect(atom.notifications.addWarning).toHaveBeenCalledWith('Blames do not exist for gists')
+          expect(githubFile.openURLInBrowser).not.toHaveBeenCalled()
+        })
+      })
     })
 
     describe('branchCompare', () => {
@@ -320,6 +354,40 @@ describe('GitHubFile', function () {
           spyOn(githubFile, 'openURLInBrowser')
           githubFile.openBranchCompare()
           expect(githubFile.openURLInBrowser).toHaveBeenCalledWith('https://github.com/some-user/some-repo/compare/master')
+        })
+      })
+
+      describe('when the file is part of a GitHub wiki', () => {
+        let fixtureName = 'github-remote-wiki'
+
+        beforeEach(async () => {
+          setupWorkingDir(fixtureName)
+          await setupGithubFile()
+        })
+
+        it('shows a warning and does not attempt to open a URL', () => {
+          spyOn(githubFile, 'openURLInBrowser')
+          spyOn(atom.notifications, 'addWarning')
+          githubFile.openBranchCompare()
+          expect(atom.notifications.addWarning).toHaveBeenCalledWith('Branches do not exist for wikis')
+          expect(githubFile.openURLInBrowser).not.toHaveBeenCalled()
+        })
+      })
+
+      describe('when the file is part of a GitHub wiki', () => {
+        let fixtureName = 'github-remote-gist'
+
+        beforeEach(async () => {
+          setupWorkingDir(fixtureName)
+          await setupGithubFile()
+        })
+
+        it('shows a warning and does not attempt to open a URL', () => {
+          spyOn(githubFile, 'openURLInBrowser')
+          spyOn(atom.notifications, 'addWarning')
+          githubFile.openBranchCompare()
+          expect(atom.notifications.addWarning).toHaveBeenCalledWith('Branches do not exist for gists')
+          expect(githubFile.openURLInBrowser).not.toHaveBeenCalled()
         })
       })
     })
@@ -513,6 +581,40 @@ describe('GitHubFile', function () {
           expect(githubFile.openURLInBrowser).toHaveBeenCalledWith('https://github.com/some-user/some-repo/issues')
         })
       })
+
+      describe('when the file is part of a GitHub wiki', () => {
+        let fixtureName = 'github-remote-wiki'
+
+        beforeEach(async () => {
+          setupWorkingDir(fixtureName)
+          await setupGithubFile()
+        })
+
+        it('shows a warning and does not attempt to open a URL', () => {
+          spyOn(githubFile, 'openURLInBrowser')
+          spyOn(atom.notifications, 'addWarning')
+          githubFile.openIssues()
+          expect(atom.notifications.addWarning).toHaveBeenCalledWith('Issues do not exist for wikis')
+          expect(githubFile.openURLInBrowser).not.toHaveBeenCalled()
+        })
+      })
+
+      describe('when the file is part of a GitHub wiki', () => {
+        let fixtureName = 'github-remote-gist'
+
+        beforeEach(async () => {
+          setupWorkingDir(fixtureName)
+          await setupGithubFile()
+        })
+
+        it('shows a warning and does not attempt to open a URL', () => {
+          spyOn(githubFile, 'openURLInBrowser')
+          spyOn(atom.notifications, 'addWarning')
+          githubFile.openIssues()
+          expect(atom.notifications.addWarning).toHaveBeenCalledWith('Issues do not exist for gists')
+          expect(githubFile.openURLInBrowser).not.toHaveBeenCalled()
+        })
+      })
     })
 
     describe('openPullRequests', () => {
@@ -528,6 +630,40 @@ describe('GitHubFile', function () {
           spyOn(githubFile, 'openURLInBrowser')
           githubFile.openPullRequests()
           expect(githubFile.openURLInBrowser).toHaveBeenCalledWith('https://github.com/some-user/some-repo/pulls')
+        })
+      })
+
+      describe('when the file is part of a GitHub wiki', () => {
+        let fixtureName = 'github-remote-wiki'
+
+        beforeEach(async () => {
+          setupWorkingDir(fixtureName)
+          await setupGithubFile()
+        })
+
+        it('shows a warning and does not attempt to open a URL', () => {
+          spyOn(githubFile, 'openURLInBrowser')
+          spyOn(atom.notifications, 'addWarning')
+          githubFile.openPullRequests()
+          expect(atom.notifications.addWarning).toHaveBeenCalledWith('Pull requests do not exist for wikis')
+          expect(githubFile.openURLInBrowser).not.toHaveBeenCalled()
+        })
+      })
+
+      describe('when the file is part of a GitHub wiki', () => {
+        let fixtureName = 'github-remote-gist'
+
+        beforeEach(async () => {
+          setupWorkingDir(fixtureName)
+          await setupGithubFile()
+        })
+
+        it('shows a warning and does not attempt to open a URL', () => {
+          spyOn(githubFile, 'openURLInBrowser')
+          spyOn(atom.notifications, 'addWarning')
+          githubFile.openPullRequests()
+          expect(atom.notifications.addWarning).toHaveBeenCalledWith('Pull requests do not exist for gists')
+          expect(githubFile.openURLInBrowser).not.toHaveBeenCalled()
         })
       })
     })


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Rather than opening a page that 404s, this PR implements informative warnings for invalid operations (for example, attempting to open the Issues page for a Gist).  To facilitate this I've added a new instance variable, `this.type`, to prevent repeated calls to `this.githubRepoURL()`.  Its values can be adjusted later if necessary.

### Alternate Designs

None.

### Benefits

No 404 pages

### Possible Drawbacks

None.

### Applicable Issues

None.