### PR TITLE
Strip username from host

### DIFF
--- a/lib/github-file.js
+++ b/lib/github-file.js
@@ -244,15 +244,17 @@ export default class GitHubFile {
   githubRepoURL () {
     let url = this.gitURL()
 
-    if (url.match(/git@[^:]+:/)) {
+    if (url.match(/git@[^:]+:/)) { // git@github.com:user/repo.git
       url = url.replace(/^git@([^:]+):(.+)$/, (match, host, repoPath) => {
         repoPath = repoPath.replace(/^\/+/, '')
-        return `http://${host}/${repoPath}`
+        return `https://${host}/${repoPath}` // -> https://github.com/user/repo.git
       })
-    } else if (url.match(/ssh:\/\/git@([^/]+)\//)) {
-      url = `http://${url.substring(10)}`
-    } else if (url.match(/^git:\/\/[^/]+\//)) {
-      url = `http${url.substring(3)}`
+    } else if (url.match(/^ssh:\/\/git@([^/]+)\//)) { // ssh://git@github.com/user/repo.git
+      url = `https://${url.substring(10)}` // -> https://github.com/user/repo.git
+    } else if (url.match(/^git:\/\/[^/]+\//)) { // git://github.com/user/repo.git
+      url = `https${url.substring(3)}` // -> https://github.com/user/repo.git
+    } else if (url.match(/^https?:\/\/\w+@/)) { // https://user@github.com/user/repo.git
+      url = url.replace(/^https?:\/\/\w+@/, 'https://') // -> https://github.com/user/repo.git
     }
 
     // Remove trailing .git and trailing slashes

--- a/spec/github-file-spec.js
+++ b/spec/github-file-spec.js
@@ -694,7 +694,7 @@ describe('GitHubFile', function () {
 
     it('returns the GitHub.com URL for an SSH remote URL', () => {
       githubFile.gitURL = () => 'git@github.com:foo/bar.git'
-      expect(githubFile.githubRepoURL()).toBe('http://github.com/foo/bar')
+      expect(githubFile.githubRepoURL()).toBe('https://github.com/foo/bar')
     })
 
     it('returns a GitHub enterprise URL for a non-Github.com remote URL', () => {
@@ -702,17 +702,22 @@ describe('GitHubFile', function () {
       expect(githubFile.githubRepoURL()).toBe('https://git.enterprize.me/foo/bar')
 
       githubFile.gitURL = () => 'git@git.enterprize.me:foo/bar.git'
-      expect(githubFile.githubRepoURL()).toBe('http://git.enterprize.me/foo/bar')
+      expect(githubFile.githubRepoURL()).toBe('https://git.enterprize.me/foo/bar')
     })
 
     it('returns the GitHub.com URL for a git:// URL', () => {
       githubFile.gitURL = () => 'git://github.com/foo/bar.git'
-      expect(githubFile.githubRepoURL()).toBe('http://github.com/foo/bar')
+      expect(githubFile.githubRepoURL()).toBe('https://github.com/foo/bar')
+    })
+
+    it('returns the GitHub.com URL for a user@github.com URL', () => {
+      githubFile.gitURL = () => 'https://user@github.com/foo/bar.git'
+      expect(githubFile.githubRepoURL()).toBe('https://github.com/foo/bar')
     })
 
     it('returns the GitHub.com URL for a ssh:// URL', () => {
       githubFile.gitURL = () => 'ssh://git@github.com/foo/bar.git'
-      expect(githubFile.githubRepoURL()).toBe('http://github.com/foo/bar')
+      expect(githubFile.githubRepoURL()).toBe('https://github.com/foo/bar')
     })
 
     it('returns undefined for Bitbucket URLs', () => {
@@ -737,7 +742,7 @@ describe('GitHubFile', function () {
       expect(githubFile.githubRepoURL()).toBe('https://github.com/foo/bar')
 
       githubFile.gitURL = () => 'git@github.com:/foo/bar.git'
-      expect(githubFile.githubRepoURL()).toBe('http://github.com/foo/bar')
+      expect(githubFile.githubRepoURL()).toBe('https://github.com/foo/bar')
     })
   })
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Takes `https://user@github.com/user/repo.git`-style URLs and returns `https://github.com/user/repo.git`.
Also uses HTTPS where possible.

### Alternate Designs

None.

### Benefits

More accurate URL.

### Possible Drawbacks

I don't see any?  Everything should continue to work as long as you're logged into GitHub.

### Applicable Issues

Fixes #72