### PR TITLE
Enable users to select which line numbering style is used.

### DIFF
--- a/lib/github-file.js
+++ b/lib/github-file.js
@@ -117,10 +117,15 @@ export default class GitHubFile {
           return `#L${startRow}`
         }
       } else {
+        // Line numbering, Github is the default style.
+        lineNumbers = `L${startRow}-L${endRow}`
+        if ('Gitlab' === atom.config.get('open-on-github.lineNumberInUrlStyle')) {
+            lineNumbers = `L${startRow}-${endRow}`
+        }
         if (this.type === 'gist') {
-          return `-L${startRow}-L${endRow}`
+          return `-` + lineNumbers
         } else {
-          return `#L${startRow}-L${endRow}`
+          return `#` + lineNumbers
         }
       }
     } else {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,15 @@
       "default": true,
       "type": "boolean",
       "description": "Include the line range selected in the editor when opening or copying URLs to the clipboard. When opened in the browser, the GitHub page will automatically scroll to the selected line range."
+    },
+    "lineNumberInUrlStyle": {
+        "default": "Github",
+        "type": "string",
+        "enum": [
+            {"value": "Github", "description": "Github style line numbering in URL: #L123-L124"},
+            {"value": "Gitlab", "description": "Gitlab style line numbering in URL: #L123-124"}
+        ],
+        "description": "Only applicable if include line numbers in Urls is enabled."
     }
   }
 }


### PR DESCRIPTION
### Description of the Change

When selecting a block of code on Github, the line numbering anchor format in the URL is #L123-L124 but Gitlab uses this format #L123-124.

This pull request adds a new setting that enables users to choose between these two styles.

### Benefits
If you're using Gitlab, currently this plugin will open the right file but the code selected in the editor is not selected in the browser. This pull request fixes things so that the code that is selected in the editor is selected in the browser.

### Possible Drawbacks
This plugin is called Open in Github, I appreciate this may be altering the scope of its use case but I did see some checks in the code related to bitbucket so I have assumed it is partly expected that users will use this plugin when their source code is hosted on none Github repositories.

